### PR TITLE
Fixing the way that an entity (or whatever is being mapped over) is stored in `last_work_item`.

### DIFF
--- a/mapreduce/handlers.py
+++ b/mapreduce/handlers.py
@@ -571,7 +571,7 @@ class MapperWorkerCallbackHandler(base_handler.HugeTaskHandler):
       elif isinstance(entity, ndb.Model):
         shard_state.last_work_item = repr(entity.key)
       else:
-        shard_state.last_work_item = repr(entity)[:100]
+        shard_state.last_work_item = unicode(entity)[:100]
 
       processing_limit -= 1
 


### PR DESCRIPTION
In python 2, `repr` should always return a str (not unicode), so given that this value gets stored in a db.TextProperty (which is stored as unicode), using `repr` is silly and results in an error for non-ascii characters.